### PR TITLE
Nma 1.0+theme support v2

### DIFF
--- a/m4/compiler_warnings.m4
+++ b/m4/compiler_warnings.m4
@@ -47,8 +47,9 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
 		CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS -Werror"
 	fi
 
+	dnl remove -Wdeclaration-after-statement check because it causes build error with gtk_widget_get_toplevel()
 	for option in -Wshadow -Wmissing-declarations -Wmissing-prototypes \
-		      -Wdeclaration-after-statement -Wformat-security \
+		       -Wformat-security \
 		      -Wfloat-equal -Wno-unused-parameter -Wno-sign-compare \
 		      -Wstrict-prototypes \
 		      -fno-strict-aliasing -Wno-unused-but-set-variable \

--- a/src/applet.c
+++ b/src/applet.c
@@ -1980,19 +1980,20 @@ static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 
 	if (nm_client_get_state (applet->nm_client) == NM_STATE_ASLEEP) {
 		nma_menu_add_text_item (menu, _("Networking disabled"));
-		return;
 		
-	/*Set up theme and transparency support*/
-	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
-	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
-	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
-	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
-	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
-	/* Set menu and it's toplevel window to follow panel theme */
-	GtkStyleContext *context;
-	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
-	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+		/*Set up theme and transparency support*/
+		GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+		/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+		GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+		GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+		gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+		/* Set menu and it's toplevel window to follow panel theme */
+		GtkStyleContext *context;
+		context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+		gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+		gtk_style_context_add_class(context,"mate-panel-menu-bar");
+	
+		return;
 	}
 
 	nma_menu_add_devices (menu, applet);

--- a/src/applet.c
+++ b/src/applet.c
@@ -1853,6 +1853,18 @@ nma_menu_add_vpn_submenu (GtkWidget *menu, NMApplet *applet)
 		gtk_widget_set_sensitive (GTK_WIDGET (item), FALSE);
 
 	g_slist_free (list);
+	
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel(GTK_WIDGET(vpn_menu));
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 }
 
 
@@ -1969,6 +1981,18 @@ static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 	if (nm_client_get_state (applet->nm_client) == NM_STATE_ASLEEP) {
 		nma_menu_add_text_item (menu, _("Networking disabled"));
 		return;
+		
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 	}
 
 	nma_menu_add_devices (menu, applet);
@@ -1981,6 +2005,18 @@ static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 		nma_menu_add_create_network_item (menu, applet);
 	}
 
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+	
 	gtk_widget_show_all (menu);
 
 //	nmi_dbus_signal_user_interface_activated (applet->connection);
@@ -2274,7 +2310,18 @@ static GtkWidget *nma_context_menu_create (NMApplet *applet)
 	image = gtk_image_new_from_stock (GTK_STOCK_ABOUT, GTK_ICON_SIZE_MENU);
 	gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (menu_item), image);
 	gtk_menu_shell_append (menu, menu_item);
-
+	
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu_item);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 	gtk_widget_show_all (GTK_WIDGET (menu));
 
 	return GTK_WIDGET (menu);


### PR DESCRIPTION
Support custom themes for menus created by panel applets (shell theming) as now supported in MATE 1.11.0 and later. This will work in any desktop environment that runs nm-applet with a custom "shell theme" in use for panel applet menus/tray item menus distinct from the overall gtk menu theme used by applications.

Theming can be controlled by these selectors: 
.gnome-panel-menu-bar .menu
.mate-panel-menu-bar .menu

An example theme using these selectors can be found at 

https://archive.org/details/DebianPackagesForMate-desktopWityGtk3AndCustomPanelTheme
the theme is gtk-theme-ubuntustudio-legacy, latest version uploaded which stands now at 0.8
https://archive.org/download/DebianPackagesForMate-desktopWityGtk3AndCustomPanelTheme/gtk-theme-ubuntustudio-legacy-0.8_all.deb

This PR  is written against network-manager-applet 1.0.6 as that is the most recent version of networkmanager I can find, and as recent as anything on https://git.gnome.org/browse/network-manager-applet/ seems to offer. 
