### PR TITLE
Support  "shell" menu themes in MATE

### DIFF
--- a/m4/compiler_options.m4
+++ b/m4/compiler_options.m4
@@ -1,37 +1,22 @@
-AC_DEFUN([_NM_COMPILER_FLAG], [
+dnl Check whether a particular compiler flag works with code provided,
+dnl disable it in CFLAGS if the check fails.
+AC_DEFUN([NM_COMPILER_WARNING], [
 	CFLAGS_SAVED="$CFLAGS"
-	CFLAGS="$CFLAGS $GLIB_CFLAGS -Werror $1"
-	AC_MSG_CHECKING([whether $1 works as expected])
+	CFLAGS="$CFLAGS -W$1"
+	AC_MSG_CHECKING(whether -W$1 works)
 
 	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[]])], [
 		AC_COMPILE_IFELSE([AC_LANG_SOURCE([[$2]])], [
 			AC_MSG_RESULT(yes)
-			CFLAGS="$CFLAGS_SAVED"
-			$3
+			CFLAGS="$CFLAGS_SAVED -W$1"
 		],[
 			AC_MSG_RESULT(no)
-			CFLAGS="$CFLAGS_SAVED"
-			$4
+			CFLAGS="$CFLAGS_SAVED -Wno-$1"
 		])
 	],[
 		AC_MSG_RESULT(not supported)
 		CFLAGS="$CFLAGS_SAVED"
 	])
-])
-
-dnl Check whether a particular compiler flag is supported,
-dnl add it to CFLAGS if it is
-AC_DEFUN([NM_COMPILER_FLAG], [
-        _NM_COMPILER_FLAG([$1], [], [
-		CFLAGS="$CFLAGS $1"
-		$2
-	], [$3])
-])
-
-dnl Check whether a particular warning is not emitted with code provided,
-dnl disable it in CFLAGS if the check fails.
-AC_DEFUN([NM_COMPILER_WARNING], [
-        _NM_COMPILER_FLAG([-W$1], [$2], [CFLAGS="$CFLAGS -W$1"], [CFLAGS="$CFLAGS -Wno-$1"])
 ])
 
 AC_DEFUN([NM_COMPILER_WARNINGS],
@@ -55,27 +40,37 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
 	dnl attach it to the CFLAGS.
 	NM_COMPILER_WARNING([unknown-warning-option], [])
 
-	CFLAGS_MORE_WARNINGS="-Wall -std=gnu89"
+	CFLAGS_SAVED="$CFLAGS"
+	CFLAGS_MORE_WARNINGS="-Wall -std=c99"
 
 	if test "x$set_more_warnings" = xerror; then
-		CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS -Werror"
+		CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS"
 	fi
 
 	for option in -Wshadow -Wmissing-declarations -Wmissing-prototypes \
 		      -Wdeclaration-after-statement -Wformat-security \
 		      -Wfloat-equal -Wno-unused-parameter -Wno-sign-compare \
-		      -Wno-duplicate-decl-specifier \
 		      -Wstrict-prototypes \
-		      -Wno-unused-but-set-variable \
-		      -Wno-format-y2k \
+		      -fno-strict-aliasing -Wno-unused-but-set-variable \
 		      -Wundef -Wimplicit-function-declaration \
-		      -Wpointer-arith -Winit-self -Wformat-nonliteral \
-		      -Wmissing-include-dirs -Wno-pragmas; do
+		      -Wpointer-arith -Winit-self \
+		      -Wmissing-include-dirs -Waggregate-return; do
 		dnl GCC 4.4 does not warn when checking for -Wno-* flags (https://gcc.gnu.org/wiki/FAQ#wnowarning)
-                _NM_COMPILER_FLAG([$(printf '%s' "$option" | sed 's/^-Wno-/-W/')], [],
-		                  [CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS $option"], [])
+		CFLAGS="$CFLAGS_MORE_WARNINGS $(printf '%s' "$option" | sed 's/^-Wno-/-W/')  $CFLAGS_SAVED"
+		AC_MSG_CHECKING([whether compiler understands $option])
+		AC_TRY_COMPILE([], [],
+			has_option=yes,
+			has_option=no,)
+		if test $has_option != no; then
+			CFLAGS_MORE_WARNINGS="$CFLAGS_MORE_WARNINGS $option"
+		fi
+		AC_MSG_RESULT($has_option)
+		unset has_option
 	done
 	unset option
+
+	CFLAGS="$CFLAGS_SAVED"
+	unset CFLAGS_SAVED
 
 	dnl Disable warnings triggered by known compiler problems
 

--- a/src/applet.c
+++ b/src/applet.c
@@ -1599,6 +1599,17 @@ static void nma_menu_show_cb (GtkWidget *menu, NMApplet *applet)
 {
 	g_return_if_fail (menu != NULL);
 	g_return_if_fail (applet != NULL);
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+		gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 
 	if (applet->status_icon)
 		gtk_status_icon_set_tooltip_text (applet->status_icon, NULL);
@@ -1888,6 +1899,17 @@ static GtkWidget *nma_context_menu_create (NMApplet *applet)
 		gtk_menu_shell_append (menu, menu_item);
 	}
 
+	/*Set up theme and transparency support*/
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 	gtk_widget_show_all (GTK_WIDGET (menu));
 
 	return GTK_WIDGET (menu);


### PR DESCRIPTION
MATE panel uses the .mate-panel-menu-bar style class to permit theming "Shell" menus popped up from the panel differently than application menus. Tray applets have to support this directly as child applications from tray applets like nm-applet render their own menus. Add this support to Network-Manager-Gnome.  

The 1.2 version is what I was able to build and test, I could NOT find source code for Network-Manager 1.3 to build the 1.3(master) version against. The change is exactly the same in any case: adding the style classes .mate-panel-menu-bar and .gnome-panel-menu-bar to two places menus are created, and ensuring that an RGBA visual is used if the WM supports it so transparent themes work even if there are compiz/GTK conflicts in non-Ubuntu cases.
