### PR TITLE
indicator: fix lock/encrypted icon not shown

### DIFF
--- a/src/ap-menu-item.c
+++ b/src/ap-menu-item.c
@@ -112,10 +112,11 @@ update_icon (NMNetworkMenuItem *item, NMApplet *applet)
 
 			if (encrypted) {
 				icon = icon_free = gdk_pixbuf_copy (icon);
-
+	                                /* Reduce width/height to avoid failed assert          */
+	                                /* dest_y >= 0 && dest_y + dest_height <= dest->height */
 				gdk_pixbuf_composite (encrypted, icon, 0, 0,
-				                      gdk_pixbuf_get_width (encrypted),
-				                      gdk_pixbuf_get_height (encrypted),
+				                      (gdk_pixbuf_get_width (encrypted) -2),
+				                      (gdk_pixbuf_get_height (encrypted) - 2),
 				                      0, 0, 1.0, 1.0,
 				                      GDK_INTERP_NEAREST, 255);
 			}


### PR DESCRIPTION
Fix failed assert dest_y >= 0 && dest_y + dest_height <= dest->height in gdk_pixbuf_composite so lock icon can show up in indicator mode. Lock icon does not appear and the failed assert warning appears if encrypted wifi signals are detected without this PR